### PR TITLE
fix source-map file name

### DIFF
--- a/src/less4clj/core.clj
+++ b/src/less4clj/core.clj
@@ -176,7 +176,7 @@
 (defn less-compile-to-file [path target-dir relative-path options]
   (let [input-file (io/file path)
         output-file (io/file target-dir (string/replace relative-path #"\.main\.less$" ".css"))
-        source-map-output (io/file target-dir (string/replace relative-path #"\.main\.less$" ".main.css.map"))
+        source-map-output (io/file target-dir (string/replace relative-path #"\.main\.less$" ".css.map"))
         {:keys [output source-map] :as result} (less-compile input-file options)]
     (when output
       (io/make-parents output-file)


### PR DESCRIPTION
This fixes the source-map filename still having ".main".  The source-map file content still referrs to the original 

```
"file":"site.main.css",
```

Not sure if this needs to be right.